### PR TITLE
Workload imbalance is shown in the Imb column.

### DIFF
--- a/common.h
+++ b/common.h
@@ -98,4 +98,20 @@ cuda_freez(T*& ptr_dev)
   ptr_dev = nullptr;
 }
 
+template<typename T, typename T2>
+inline bool set_max(T& accum, const T2& v)
+{
+  if ( v <= accum ) return false;
+  accum = v;
+  return true;
+}
+
+template<typename T, typename T2>
+inline bool set_min(T& accum, const T2& v)
+{
+  if ( v >= accum ) return false;
+  accum = v;
+  return true;
+}
+
 #endif /* COMMON_H */

--- a/mat.cu
+++ b/mat.cu
@@ -1,14 +1,6 @@
 #include "mat.cuh"
 #include <bit>
 
-template<typename T, typename T2>
-bool set_max(T& accum, const T2& v)
-{
-  if ( v <= accum ) return false;
-  accum = v;
-  return true;
-}
-
 __constant__ Mat_POD mat_dev;
 
 Mat::Mat(DataLoader& input, int tileh,int tilew)


### PR DESCRIPTION
A value of 0 is ideal, meaning that all SMs are busy for the same amount of time. A value of 100 means that execution time was 100% longer (twice as long) as the execution time of a perfectly balanced workload, a value of 120 means that execution time was 120% longer (1.20+1.00 = 2.20 times longer) than it would be if the workload were perfectly balanced.

Code Changes:

 Collect per-warp start and end times, as well as SM id.

 Some cleanup of the code using CUDA events to measure timing, though
 a bug in NPerf still inflates the CUDA event durations.

common.h
 Move set_max from mat.cu to common.h. New: set_min.