### PR TITLE
resCheck: Fix and tighten error tolerance. Mat::row_nnz_get.

### DIFF
--- a/mat.cuh
+++ b/mat.cuh
@@ -94,6 +94,8 @@ class Mat : public Mat_POD{
   std::vector<uint> seg_lg_nnz_histo;
   int64_t n_col_sum; // Sum of population of bitMaps == num nz cols in tiles.
 
+  int row_nnz_get(int r) const { return rowPtr[r+1] - rowPtr[r]; }
+
 	void csr2seg_Cmajor(int i);
 	void csr2flex_Rmajor(int i);
 	void csr2flex_Cmajor(int i);


### PR DESCRIPTION
 * Replace abs (integer absolute value) with fabs. Note: std::abs would have done a FP-absolute value, but not ::abs.
 * Compute a much tighter tolerance for the error check. The tolerance is chosen for A and B matrix elements in the range [-1,1]. If elements are much smaller than that some errors will not be caught.
 * New: Mat::row_nnz_get.